### PR TITLE
Add validation split

### DIFF
--- a/test.ipynb
+++ b/test.ipynb
@@ -4,7 +4,11 @@
    "cell_type": "markdown",
    "id": "d7e8fc45",
    "metadata": {},
-   "source": []
+   "source": [
+    "Ce notebook montre comment préparer des données Open Food Facts pour entraîner un modèle évaluant la compatibilité d'une liste d'ingrédients.\n",
+    "\n",
+    "Le bloc suivant extrait du fichier JSONL compressé un CSV `ingredients.csv` plus facile à manipuler.\n"
+   ]
   },
   {
    "cell_type": "code",
@@ -51,7 +55,7 @@
    "id": "1848d682",
    "metadata": {},
    "source": [
-    "    "
+    "**Chargement et nettoyage** : on ouvre `ingredients.csv`, on met le texte en minuscules, on retire la ponctuation superflue puis on découpe les listes en tokens (colonne `tokens`).\n"
    ]
   },
   {
@@ -90,24 +94,31 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "",
+   "source": [
+    "**EntraÃ®nement d'un modÃ¨le Word2Vec** pour obtenir des vecteurs reprÃ©sentant chaque ingrÃ©dient Ã  partir des tokens.\n",
+    "\n",
+    "**Optimisation** : on rÃ¨gle `workers=os.cpu_count()` pour exploiter tous les cÅurs du processeur. Gensim ne profite pas directement du GPU (RTXÂ 2050) mais la parallÃ©lisation CPU rÃ©duit nettement le temps d'Ã©ntraÃ®nement sur un i9.\n"
+   ],
    "id": "60e25a655d327a86"
   },
   {
    "metadata": {},
    "cell_type": "code",
    "source": [
+    "import os\n",
     "from gensim.models import Word2Vec\n",
     "\n",
     "sentences = df['tokens'].tolist()\n",
     "\n",
+    "num_workers = os.cpu_count()  # utilise tous les coeurs\n",
     "w2v = Word2Vec(\n",
     "    sentences,\n",
     "    vector_size=100,\n",
     "    window=5,\n",
     "    min_count=5,\n",
     "    sg=1,\n",
-    "    epochs=10\n",
+    "    epochs=10,\n",
+    "    workers=num_workers,\n",
     ")\n",
     "\n",
     "vec_tomate = w2v.wv['tomate']\n"
@@ -119,7 +130,9 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "",
+   "source": [
+    "**Embedding moyen par produit** : on calcule la moyenne des vecteurs d'ingrédients pour chaque liste (`list_emb`).\n"
+   ],
    "id": "74bdc9545a3aa979"
   },
   {
@@ -141,18 +154,51 @@
    "execution_count": null
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Score de compatibilité automatique** : on mesure la similarité moyenne entre toutes les paires d'ingrédients pour produire un score dans l'intervalle [0,1].\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def compatibility_score(tokens, model):\n",
+    "    pairs = []\n",
+    "    for i in range(len(tokens)):\n",
+    "        for j in range(i+1, len(tokens)):\n",
+    "            if tokens[i] in model.wv and tokens[j] in model.wv:\n",
+    "                pairs.append(model.wv.similarity(tokens[i], tokens[j]))\n",
+    "    if not pairs:\n",
+    "        return 0.5\n",
+    "    sim = float(np.mean(pairs))\n",
+    "    return (sim + 1) / 2\n",
+    "\n",
+    "df['score'] = df['tokens'].apply(lambda toks: compatibility_score(toks, w2v))\n"
+   ]
+  },
+  {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "",
+   "source": [
+  "**Préparation des données d'entraînement** : `X` regroupe les embeddings moyens et `y` contient les scores calculés précédemment. On sépare ensuite les données en ensembles d'entraînement (60%), validation (20%) et test (20%).\n"
+   ],
    "id": "3d981e66dc4e374e"
   },
   {
    "metadata": {},
    "cell_type": "code",
    "source": [
-    "X = np.vstack(df['list_emb'].values)\n",
-    "\n",
-    "y = df['score'].values / 100.0\n"
+  "from sklearn.model_selection import train_test_split\n",
+  "\n",
+  "X = np.vstack(df['list_emb'].values)\n",
+  "y = df['score'].values\n",
+  "\n",
+  "X_tmp, X_test, y_tmp, y_test = train_test_split(X, y, test_size=0.2, random_state=42)\n",
+  "X_train, X_val, y_train, y_val = train_test_split(X_tmp, y_tmp, test_size=0.25, random_state=42)  # 60% train, 20% val, 20% test\n"
    ],
    "id": "2626fd4233e774a3",
    "outputs": [],
@@ -161,14 +207,23 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "",
+   "source": [
+  "**Entraînement et évaluation du réseau** : on définit `ScoringNet`, sépare les données en ensembles d'entraînement, de validation et de test, construit un DataLoader puis on entraîne le modèle. Si un GPU est disponible, le modèle et les batchs y sont transférés pour accélérer l'entraînement. Après chaque époque on mesure l'erreur quadratique moyenne sur la validation, puis on termine avec un calcul sur le jeu de test et un nuage de points comparant score calculé et prédiction.\n"
+   ],
    "id": "854506a1b9d45b64"
   },
   {
    "metadata": {},
    "cell_type": "code",
    "source": [
+    "import os\n",
     "import torch, torch.nn as nn, torch.optim as optim\n",
+    "from torch.utils.data import TensorDataset, DataLoader\n",
+    "from sklearn.metrics import mean_squared_error\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
+    "torch.backends.cudnn.benchmark = True\n",
     "\n",
     "class ScoringNet(nn.Module):\n",
     "    def __init__(self, emb_dim=100):\n",
@@ -176,20 +231,59 @@
     "        self.net = nn.Sequential(\n",
     "            nn.Linear(emb_dim, 64),\n",
     "            nn.ReLU(),\n",
-    "            nn.Linear(64, 1),   # sortie scalaire\n",
-    "            nn.Sigmoid()        # donne un score dans [0,1]\n",
+    "            nn.Linear(64, 1),\n",
+    "            nn.Sigmoid()\n",
     "        )\n",
+    "\n",
     "    def forward(self, x):\n",
     "        return self.net(x)\n",
     "\n",
-    "# Préparer DataLoader…\n",
-    "# Convertir X_train, y_train en TensorDataset puis DataLoader\n",
-    "# Boucle d’entraînement classique avec MSELoss et AdamW\n",
-    "\n"
+  "X_t = torch.tensor(X_train, dtype=torch.float32)\n",
+  "y_t = torch.tensor(y_train.reshape(-1, 1), dtype=torch.float32)\n",
+  "ds = TensorDataset(X_t, y_t)\n",
+  "loader = DataLoader(ds, batch_size=32, shuffle=True, num_workers=os.cpu_count(), pin_memory=(device.type=='cuda'))\n",
+  "\n",
+  "X_val_t = torch.tensor(X_val, dtype=torch.float32, device=device)\n",
+  "y_val_t = torch.tensor(y_val.reshape(-1, 1), dtype=torch.float32, device=device)\n",
+    "\n",
+    "model = ScoringNet(X.shape[1]).to(device)\n",
+    "opt = optim.AdamW(model.parameters(), lr=1e-3)\n",
+    "crit = nn.MSELoss()\n",
+    "\n",
+  "for epoch in range(5):\n",
+  "    for xb, yb in loader:\n",
+  "        xb = xb.to(device, non_blocking=True)\n",
+  "        yb = yb.to(device, non_blocking=True)\n",
+  "        opt.zero_grad()\n",
+  "        pred = model(xb)\n",
+  "        loss = crit(pred, yb)\n",
+  "        loss.backward()\n",
+  "        opt.step()\n",
+  "    with torch.no_grad():\n",
+  "        val_pred = model(X_val_t).cpu().numpy().ravel()\n",
+  "    val_mse = mean_squared_error(y_val, val_pred)\n",
+  "    print(f'epoch {epoch} loss {loss.item():.4f} val_mse {val_mse:.4f}')\n",
+    "\n",
+    "model.eval()\n",
+    "with torch.no_grad():\n",
+    "    preds = model(torch.tensor(X_test, dtype=torch.float32, device=device)).cpu().numpy().ravel()\n",
+    "test_mse = mean_squared_error(y_test, preds)\n",
+    "print('Test MSE:', test_mse)\n",
+    "plt.scatter(y_test, preds, alpha=0.5)\n",
+    "plt.xlabel('True score')\n",
+    "plt.ylabel('Predicted score')\n",
+    "plt.show()\n"
    ],
    "id": "875c69ff38817bc2",
    "outputs": [],
    "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+  "Le graphique résultant permet de visualiser la corrélation entre la valeur calculée par Word2Vec (`y_test`) et la prédiction du réseau (`preds`). Un alignement proche de la diagonale indique que le modèle reproduit bien le score automatique. Les pertes de validation affichées après chaque époque servent à suivre la convergence avant d'évaluer une dernière fois sur le jeu de test.\n"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
- split list embeddings into train, validation and test sets
- track validation loss during training
- clarify dataset split explanation
- note purpose of validation set in final notes

## Testing
- `jq empty test.ipynb`


------
https://chatgpt.com/codex/tasks/task_e_68626aa930b4832297d168c85b9650e7